### PR TITLE
feat: add environment-based Django settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "django>=5.2",
+    "django-environ>=0.12.0",
     "fastapi>=0.116.1",
     "psycopg[binary]>=3.2.9",
     "redis>=6.4.0",

--- a/src/axiomflow/__init__.py
+++ b/src/axiomflow/__init__.py
@@ -1,0 +1,1 @@
+"""Core AxiomFlow package."""

--- a/src/axiomflow/settings/__init__.py
+++ b/src/axiomflow/settings/__init__.py
@@ -1,0 +1,1 @@
+"""Django settings package for AxiomFlow."""

--- a/src/axiomflow/settings/base.py
+++ b/src/axiomflow/settings/base.py
@@ -1,0 +1,59 @@
+"""Base Django settings.
+
+Environment variables are loaded using ``django-environ``. These settings are
+shared across all environments.
+
+Attributes:
+    env (environ.Env): Environment helper for reading variables.
+    BASE_DIR (Path): Root directory of the project.
+    SECRET_KEY (str): Secret key from ``DJANGO_SECRET_KEY``.
+    INSTALLED_APPS (list[str]): Core Django applications.
+    MIDDLEWARE (list[str]): Default middleware stack.
+    TEMPLATES (list[dict]): Template engine configuration.
+"""
+
+from pathlib import Path
+
+import environ
+
+env = environ.Env()
+environ.Env.read_env()
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+SECRET_KEY = env("DJANGO_SECRET_KEY")
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]

--- a/src/axiomflow/settings/development.py
+++ b/src/axiomflow/settings/development.py
@@ -1,0 +1,26 @@
+"""Development settings.
+
+Extends base settings with debugging helpers, SQLite fallback, and local-memory
+caching.
+
+Attributes:
+    DEBUG (bool): Enables Django debug mode.
+    DATABASES (dict): Database configuration using ``DATABASE_URL`` or SQLite.
+    CACHES (dict): Local-memory cache backend.
+"""
+
+from importlib import util
+
+from .base import BASE_DIR, INSTALLED_APPS, MIDDLEWARE, env
+
+DEBUG = True
+
+DATABASES = {
+    "default": env.db("DATABASE_URL", default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}")
+}
+
+CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+
+if util.find_spec("debug_toolbar"):
+    INSTALLED_APPS.append("debug_toolbar")
+    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")

--- a/src/axiomflow/settings/production.py
+++ b/src/axiomflow/settings/production.py
@@ -1,0 +1,24 @@
+"""Production settings.
+
+Configures the application for deployed environments. Debugging is disabled and
+all critical values are pulled from environment variables.
+
+Attributes:
+    DEBUG (bool): Always ``False`` in production.
+    ALLOWED_HOSTS (list[str]): Allowed hostnames from ``DJANGO_ALLOWED_HOSTS``.
+    DATABASES (dict): Database configuration from ``DATABASE_URL``.
+    CACHES (dict): Cache configuration from ``CACHE_URL``.
+    THIRD_PARTY_API_KEY (str): Example external service credential.
+"""
+
+from .base import env
+
+DEBUG = False
+
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=[])
+
+DATABASES = {"default": env.db("DATABASE_URL")}
+
+CACHES = {"default": env.cache("CACHE_URL", default="locmemcache://")}
+
+THIRD_PARTY_API_KEY = env("THIRD_PARTY_API_KEY", default="")

--- a/src/axiomflow/settings/testing.py
+++ b/src/axiomflow/settings/testing.py
@@ -1,0 +1,18 @@
+"""Testing settings.
+
+Provides configuration for running the test suite with an in-memory SQLite
+backend and local-memory caching.
+
+Attributes:
+    DEBUG (bool): Enables debug mode during tests.
+    DATABASES (dict): In-memory SQLite database configuration.
+    CACHES (dict): Local-memory cache backend.
+"""
+
+from .base import INSTALLED_APPS, MIDDLEWARE  # noqa: F401
+
+DEBUG = True
+
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+
+CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },
+    { name = "django-environ" },
     { name = "fastapi" },
     { name = "psycopg", extra = ["binary"] },
     { name = "redis" },
@@ -59,6 +60,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2" },
+    { name = "django-environ", specifier = ">=0.12.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
     { name = "redis", specifier = ">=6.4.0" },
@@ -211,6 +213,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/9b/779f853c3d2d58b9e08346061ff3e331cdec3fe3f53aae509e256412a593/django-5.2.5.tar.gz", hash = "sha256:0745b25681b129a77aae3d4f6549b62d3913d74407831abaa0d9021a03954bae", size = 10859748, upload-time = "2025-08-06T08:26:29.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/6e/98a1d23648e0085bb5825326af17612ecd8fc76be0ce96ea4dc35e17b926/django-5.2.5-py3-none-any.whl", hash = "sha256:2b2ada0ee8a5ff743a40e2b9820d1f8e24c11bac9ae6469cd548f0057ea6ddcd", size = 8302999, upload-time = "2025-08-06T08:26:23.562Z" },
+]
+
+[[package]]
+name = "django-environ"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/04/65d2521842c42f4716225f20d8443a50804920606aec018188bbee30a6b0/django_environ-0.12.0.tar.gz", hash = "sha256:227dc891453dd5bde769c3449cf4a74b6f2ee8f7ab2361c93a07068f4179041a", size = 56804, upload-time = "2025-01-13T17:03:37.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/b3/0a3bec4ecbfee960f39b1842c2f91e4754251e0a6ed443db9fe3f666ba8f/django_environ-0.12.0-py2.py3-none-any.whl", hash = "sha256:92fb346a158abda07ffe6eb23135ce92843af06ecf8753f43adf9d2366dcc0ca", size = 19957, upload-time = "2025-01-13T17:03:32.918Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- define base Django settings with environment-sourced secret key, apps, middleware and template config
- add development and testing settings with debug helpers, SQLite fallback and in-memory caching
- add production settings with DEBUG disabled and environment-driven hosts, database, cache and API credentials

## Testing
- `uv run black . && uv run isort . && uv run ruff check .`
- `uv run bandit -r src/`
- `DJANGO_SECRET_KEY=test uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68b64b65e3108322a3ad6c3325bca1b9