### PR TITLE
feat: validate database and cache configuration

### DIFF
--- a/src/axiomflow/settings/base.py
+++ b/src/axiomflow/settings/base.py
@@ -1,20 +1,27 @@
 """Base Django settings.
 
 Environment variables are loaded using ``django-environ``. These settings are
-shared across all environments.
+shared across all environments. Database and cache connections rely on
+``DATABASE_URL`` and ``REDIS_URL`` environment variables, respectively.
 
 Attributes:
     env (environ.Env): Environment helper for reading variables.
     BASE_DIR (Path): Root directory of the project.
     SECRET_KEY (str): Secret key from ``DJANGO_SECRET_KEY``.
+    DATABASES (dict): Database configuration derived from ``DATABASE_URL``.
+    CACHES (dict): Cache configuration derived from ``REDIS_URL`` with a
+        fallback to local memory.
     INSTALLED_APPS (list[str]): Core Django applications.
     MIDDLEWARE (list[str]): Default middleware stack.
     TEMPLATES (list[dict]): Template engine configuration.
 """
 
 from pathlib import Path
+from urllib.parse import urlparse
 
 import environ
+from django.core.exceptions import ImproperlyConfigured
+from pydantic import BaseModel, PostgresDsn, ValidationError, model_validator
 
 env = environ.Env()
 environ.Env.read_env()
@@ -22,6 +29,80 @@ environ.Env.read_env()
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 SECRET_KEY = env("DJANGO_SECRET_KEY")
+
+
+class DatabaseURL(BaseModel):
+    """Validate the ``DATABASE_URL`` environment variable.
+
+    Ensures the connection string includes user, password, host, and
+    database name using the PostgreSQL DSN format, for example::
+
+        postgresql://user:pass@host:5432/db
+    """
+
+    url: PostgresDsn
+
+    @model_validator(mode="after")
+    def ensure_components(self) -> "DatabaseURL":
+        parsed = urlparse(str(self.url))
+        if not all(
+            [
+                parsed.username,
+                parsed.password,
+                parsed.hostname,
+                parsed.path.lstrip("/"),
+            ]
+        ):
+            raise ValueError(
+                "DATABASE_URL must include user, password, host, and database name"
+            )
+        return self
+
+
+try:
+    _db_settings = DatabaseURL(url=env("DATABASE_URL"))
+except ValidationError as exc:  # pragma: no cover - configuration validation
+    raise ImproperlyConfigured("Invalid DATABASE_URL") from exc
+
+_parsed_db_url = urlparse(str(_db_settings.url))
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": _parsed_db_url.path.lstrip("/"),
+        "USER": _parsed_db_url.username,
+        "PASSWORD": _parsed_db_url.password,
+        "HOST": _parsed_db_url.hostname,
+        "PORT": str(_parsed_db_url.port or 5432),
+    }
+}
+"""Database configuration derived from ``DATABASE_URL``.
+
+The environment variable must be a fully qualified PostgreSQL connection
+string including user, password, host, port, and database name.
+"""
+
+
+_redis_url = env.str("REDIS_URL", default="")
+
+if _redis_url:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": _redis_url,
+        }
+    }
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+"""Cache backend configuration.
+
+If ``REDIS_URL`` is provided, a Redis cache backend is used. Otherwise, a
+local-memory cache backend is configured.
+"""
 
 INSTALLED_APPS = [
     "django.contrib.admin",


### PR DESCRIPTION
## Summary
- validate DATABASE_URL with pydantic and configure Django DATABASES
- add Redis cache support with REDIS_URL and locmem fallback
- document database and cache settings with comprehensive docstrings

## Testing
- `uv run isort .`
- `uv run black .`
- `uv run ruff check .`
- `uv run bandit -r src/`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68b64c8868d48322b45568beca3c20f3