### PR TITLE
docs: document structured logging with correlation ids

### DIFF
--- a/src/axiomflow/settings/base.py
+++ b/src/axiomflow/settings/base.py
@@ -14,6 +14,12 @@ Attributes:
     INSTALLED_APPS (list[str]): Core Django applications.
     MIDDLEWARE (list[str]): Default middleware stack.
     TEMPLATES (list[dict]): Template engine configuration.
+    LOGGING (dict): Structured logging with correlation IDs.
+
+Structured logging emits JSON to stdout for container compatibility. The
+``CorrelationIdMiddleware`` reads an ``X-Request-ID`` header or generates a UUID
+and stores it in a context variable. ``CorrelationIdFilter`` attaches this value
+to each log record so requests can be traced across services.
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Summary
- document how correlation IDs propagate from middleware into JSON-formatted logs

## Testing
- `uv run black .`
- `uv run isort .`
- `uv run ruff check .`
- `uv run bandit -r src/`
- `pnpm audit` *(fails: No pnpm-lock.yaml found)*
- `uv run pytest tests/ --cov=src/` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68b71a7aebd48322b14645052529d5b4