### PR TITLE
feat: add RBAC mapping and security settings

### DIFF
--- a/src/axiomflow/settings/base.py
+++ b/src/axiomflow/settings/base.py
@@ -22,6 +22,7 @@ and stores it in a context variable. ``CorrelationIdFilter`` attaches this value
 to each log record so requests can be traced across services.
 """
 
+from enum import StrEnum
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -119,6 +120,10 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
 ]
 
+# Authentication configuration
+AUTH_USER_MODEL = env.str("AUTH_USER_MODEL", default="auth.User")
+AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "axiomflow.middleware.CorrelationIdMiddleware",
@@ -146,6 +151,20 @@ TEMPLATES = [
     }
 ]
 
+# Session and CSRF security settings
+SESSION_COOKIE_AGE = env.int("SESSION_COOKIE_AGE", default=60 * 60 * 24)
+SESSION_EXPIRE_AT_BROWSER_CLOSE = env.bool(
+    "SESSION_EXPIRE_AT_BROWSER_CLOSE", default=False
+)
+SESSION_COOKIE_SECURE = env.bool("SESSION_COOKIE_SECURE", default=True)
+SESSION_COOKIE_HTTPONLY = env.bool("SESSION_COOKIE_HTTPONLY", default=True)
+SESSION_COOKIE_SAMESITE = env.str("SESSION_COOKIE_SAMESITE", default="Lax")
+
+CSRF_COOKIE_SECURE = env.bool("CSRF_COOKIE_SECURE", default=True)
+CSRF_COOKIE_HTTPONLY = env.bool("CSRF_COOKIE_HTTPONLY", default=True)
+CSRF_COOKIE_SAMESITE = env.str("CSRF_COOKIE_SAMESITE", default="Lax")
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
+
 
 # Structured logging configuration.
 
@@ -171,3 +190,62 @@ LOGGING = {
     },
     "root": {"handlers": ["console"], "level": "INFO"},
 }
+
+
+class Permission(StrEnum):
+    """Permission categories for role-based access control.
+
+    Attributes:
+        MANAGE_USERS: Create, update, and delete user accounts.
+        MANAGE_WORKFLOWS: Create and modify workflow definitions.
+        RUN_WORKFLOWS: Start and control workflow executions.
+        VIEW_WORKFLOWS: Read workflows, runs, and artifacts.
+    """
+
+    MANAGE_USERS = "manage_users"
+    MANAGE_WORKFLOWS = "manage_workflows"
+    RUN_WORKFLOWS = "run_workflows"
+    VIEW_WORKFLOWS = "view_workflows"
+
+
+class Role(StrEnum):
+    """RBAC roles available within the platform.
+
+    The roles form a hierarchy where each level inherits permissions from the
+    levels below it.
+
+    Attributes:
+        OWNER: Full control over the system and all workspaces.
+        ADMIN: Manage a workspace and its user membership.
+        EDITOR: Modify workflow definitions and configuration.
+        RUNNER: Execute existing workflows without modification rights.
+        VIEWER: Read-only access to workflows and execution results.
+    """
+
+    OWNER = "owner"
+    ADMIN = "admin"
+    EDITOR = "editor"
+    RUNNER = "runner"
+    VIEWER = "viewer"
+
+
+ROLE_PERMISSIONS: dict[Role, set[Permission]] = {
+    Role.OWNER: set(Permission),
+    Role.ADMIN: {
+        Permission.MANAGE_USERS,
+        Permission.MANAGE_WORKFLOWS,
+        Permission.RUN_WORKFLOWS,
+        Permission.VIEW_WORKFLOWS,
+    },
+    Role.EDITOR: {
+        Permission.MANAGE_WORKFLOWS,
+        Permission.RUN_WORKFLOWS,
+        Permission.VIEW_WORKFLOWS,
+    },
+    Role.RUNNER: {
+        Permission.RUN_WORKFLOWS,
+        Permission.VIEW_WORKFLOWS,
+    },
+    Role.VIEWER: {Permission.VIEW_WORKFLOWS},
+}
+"""Mapping of RBAC roles to their permitted actions."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,35 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+os.environ.setdefault("DJANGO_SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost:5432/db")
+
+from axiomflow.settings import base
+
+
+def test_auth_settings_defined():
+    assert base.AUTH_USER_MODEL == os.getenv("AUTH_USER_MODEL", "auth.User")
+    assert base.AUTHENTICATION_BACKENDS == ["django.contrib.auth.backends.ModelBackend"]
+
+
+def test_role_permissions_hierarchy():
+    perms = base.ROLE_PERMISSIONS
+    assert perms[base.Role.VIEWER] == {base.Permission.VIEW_WORKFLOWS}
+    assert perms[base.Role.RUNNER] >= perms[base.Role.VIEWER]
+    assert perms[base.Role.EDITOR] >= perms[base.Role.RUNNER]
+    assert perms[base.Role.ADMIN] >= perms[base.Role.EDITOR]
+    assert perms[base.Role.OWNER] >= perms[base.Role.ADMIN]
+
+
+def test_session_cookie_secure_env(monkeypatch):
+    module = importlib.import_module("axiomflow.settings.base")
+    monkeypatch.setenv("SESSION_COOKIE_SECURE", "False")
+    importlib.reload(module)
+    assert module.SESSION_COOKIE_SECURE is False
+    monkeypatch.delenv("SESSION_COOKIE_SECURE", raising=False)
+    importlib.reload(module)
+    assert module.SESSION_COOKIE_SECURE is True


### PR DESCRIPTION
## Summary
- configure custom user model and authentication backend
- harden session and CSRF cookies using environment-driven settings
- define RBAC roles with permission mapping

## Testing
- `uv run isort .`
- `uv run ruff check .`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68b71b5873c48322a05ae8b3a25faa2f