### PR TITLE
feat: add orchestrator configuration schema

### DIFF
--- a/configs/orchestrator.yaml
+++ b/configs/orchestrator.yaml
@@ -1,0 +1,12 @@
+# Orchestrator configuration
+# API credentials and other secrets are supplied via environment variables.
+# For example, set ORCHESTRATOR_API_KEY in your shell before starting the service.
+orchestrator:
+  workflow_timeout: 300  # seconds before a workflow times out
+  default_agent: coder  # default agent used when none specified
+  routing_policies:
+    - task: code_review
+      agent: reviewer
+    - task: test_execution
+      agent: tester
+  api_key: ${ORCHESTRATOR_API_KEY}  # provided via environment variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "django-environ>=0.12.0",
     "fastapi>=0.116.1",
     "psycopg[binary]>=3.2.9",
+    "pydantic>=2.11.7",
     "redis>=6.4.0",
 ]
 

--- a/src/axiomflow/core/__init__.py
+++ b/src/axiomflow/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core utilities for AxiomFlow."""

--- a/src/axiomflow/core/config.py
+++ b/src/axiomflow/core/config.py
@@ -1,0 +1,72 @@
+"""Pydantic models for orchestrator configuration.
+
+These schemas load and validate the ``configs/orchestrator.yaml`` file,
+ensuring that orchestrator settings are treated as code and validated at
+runtime.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class RoutingPolicy(BaseModel):
+    """Route tasks to specific agents."""
+
+    task: str
+    agent: str
+
+
+class OrchestratorConfig(BaseModel):
+    """Runtime parameters for the orchestrator.
+
+    The schema enforces configuration as code by validating and typing
+    the orchestrator settings defined in ``configs/orchestrator.yaml``.
+    Developers can reason about configuration changes similarly to
+    code changes.
+    """
+
+    workflow_timeout: int = Field(
+        ..., gt=0, description="Maximum seconds a workflow may run"
+    )
+    default_agent: str
+    routing_policies: List[RoutingPolicy] = Field(default_factory=list)
+    api_key: str | None = None
+
+    @classmethod
+    def load(cls, path: Path) -> "OrchestratorConfig":
+        """Load configuration from a YAML file.
+
+        Args:
+            path: Path to the orchestrator YAML file.
+
+        Returns:
+            Parsed and validated ``OrchestratorConfig`` instance.
+
+        Raises:
+            ValidationError: If the YAML content does not conform to the schema.
+        """
+        raw = path.read_text()
+        expanded = os.path.expandvars(raw)
+        data = yaml.safe_load(expanded)
+        return cls.model_validate(data["orchestrator"])
+
+
+def load_orchestrator_config(path: Path | None = None) -> OrchestratorConfig:
+    """Convenience function to load orchestrator configuration.
+
+    Args:
+        path: Optional path to the YAML configuration. Defaults to
+            ``configs/orchestrator.yaml``.
+
+    Returns:
+        An ``OrchestratorConfig`` instance loaded from the specified file.
+    """
+    if path is None:
+        path = Path(__file__).resolve().parents[3] / "configs" / "orchestrator.yaml"
+    return OrchestratorConfig.load(path)

--- a/tests/test_orchestrator_config.py
+++ b/tests/test_orchestrator_config.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from axiomflow.core.config import OrchestratorConfig, load_orchestrator_config
+
+
+def test_load_orchestrator_config(monkeypatch):
+    cfg_path = Path(__file__).resolve().parents[1] / "configs" / "orchestrator.yaml"
+    monkeypatch.setenv("ORCHESTRATOR_API_KEY", "test-key")
+    config = OrchestratorConfig.load(cfg_path)
+    assert config.workflow_timeout == 300
+    assert config.api_key == "test-key"
+    assert config.routing_policies[0].task == "code_review"
+    assert config.routing_policies[0].agent == "reviewer"
+
+
+def test_default_loader(monkeypatch):
+    monkeypatch.setenv("ORCHESTRATOR_API_KEY", "another-key")
+    config = load_orchestrator_config()
+    assert config.api_key == "another-key"

--- a/uv.lock
+++ b/uv.lock
@@ -43,6 +43,7 @@ dependencies = [
     { name = "django-environ" },
     { name = "fastapi" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
     { name = "redis" },
 ]
 
@@ -63,6 +64,7 @@ requires-dist = [
     { name = "django-environ", specifier = ">=0.12.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
+    { name = "pydantic", specifier = ">=2.11.7" },
     { name = "redis", specifier = ">=6.4.0" },
 ]
 


### PR DESCRIPTION
## Summary
- add orchestrator.yaml for workflow timeouts and agent routing
- load orchestrator config via Pydantic with environment variable support
- cover configuration loading with unit tests

## Testing
- `uv run ruff check src/axiomflow/core/config.py tests/test_orchestrator_config.py`
- `uv run bandit -r src/`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68b71c89c7a483229449da7b201105a5