### PR TITLE
feat: add config loader with env overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "fastapi>=0.116.1",
     "psycopg[binary]>=3.2.9",
     "pydantic>=2.11.7",
+    "pydantic-settings>=2.10.1",
     "redis>=6.4.0",
 ]
 

--- a/tests/test_orchestrator_config.py
+++ b/tests/test_orchestrator_config.py
@@ -1,22 +1,42 @@
 import sys
+import types
 from pathlib import Path
+
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from axiomflow.core.config import OrchestratorConfig, load_orchestrator_config
+from axiomflow.core import config as cfg_module
+from axiomflow.core.config import Config, get_settings, setup_django_settings
 
 
-def test_load_orchestrator_config(monkeypatch):
+@pytest.fixture(autouse=True)
+def reset_settings():
+    """Reset cached settings between tests."""
+
+    cfg_module._settings = None
+
+
+def test_load_config(monkeypatch):
     cfg_path = Path(__file__).resolve().parents[1] / "configs" / "orchestrator.yaml"
     monkeypatch.setenv("ORCHESTRATOR_API_KEY", "test-key")
-    config = OrchestratorConfig.load(cfg_path)
+    config = Config.load(cfg_path)
     assert config.workflow_timeout == 300
     assert config.api_key == "test-key"
     assert config.routing_policies[0].task == "code_review"
     assert config.routing_policies[0].agent == "reviewer"
 
 
-def test_default_loader(monkeypatch):
+def test_get_settings(monkeypatch):
     monkeypatch.setenv("ORCHESTRATOR_API_KEY", "another-key")
-    config = load_orchestrator_config()
+    config = get_settings()
     assert config.api_key == "another-key"
+
+
+def test_setup_django_settings(monkeypatch):
+    monkeypatch.setenv("ORCHESTRATOR_API_KEY", "secret")
+    settings_module = types.SimpleNamespace()
+    cfg = setup_django_settings(settings_module)
+    assert settings_module.ORCHESTRATOR_WORKFLOW_TIMEOUT == cfg.workflow_timeout
+    assert settings_module.ORCHESTRATOR_DEFAULT_AGENT == cfg.default_agent
+    assert settings_module.ORCHESTRATOR_API_KEY == "secret"

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "redis" },
 ]
 
@@ -65,6 +66,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "redis", specifier = ">=6.4.0" },
 ]
 
@@ -438,6 +440,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -486,6 +502,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/fb/55d580352db26eb3d59ad50c64321ddfe228d3d8ac107db05387a2fadf3a/pytest_django-4.11.1.tar.gz", hash = "sha256:a949141a1ee103cb0e7a20f1451d355f83f5e4a5d07bdd4dcfdd1fd0ff227991", size = 86202, upload-time = "2025-04-03T18:56:09.338Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/ac/bd0608d229ec808e51a21044f3f2f27b9a37e7a0ebaca7247882e67876af/pytest_django-4.11.1-py3-none-any.whl", hash = "sha256:1b63773f648aa3d8541000c26929c1ea63934be1cfa674c76436966d73fe6a10", size = 25281, upload-time = "2025-04-03T18:56:07.678Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add pydantic-settings dependency for typed env config
- implement Config class with env overrides and Django injection helpers
- test configuration loading and Django settings injection

## Testing
- `uv run isort .`
- `uv run black .`
- `uv run ruff check .`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68b71d8440e483228bde384fbfff10a8