### PR TITLE
feat: add project initialization CLI

### DIFF
--- a/src/axiomflow/cli/__init__.py
+++ b/src/axiomflow/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line utilities for AxiomFlow."""

--- a/src/axiomflow/cli/init_project.py
+++ b/src/axiomflow/cli/init_project.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Sequence
+
+import click
+import yaml
+
+
+@click.command("init-project")
+@click.option("--name", required=True, help="Name of the project.")
+@click.option("--owner", required=True, help="Owner of the project.")
+@click.option(
+    "--policy",
+    "policies",
+    multiple=True,
+    help="Policy identifiers to apply to the project.",
+)
+@click.option(
+    "--secret",
+    "secrets",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    help="Paths to secret files to mount into the project.",
+)
+@click.argument(
+    "directory", type=click.Path(file_okay=False, path_type=Path), default=Path(".")
+)
+def init_project(
+    name: str,
+    owner: str,
+    policies: Sequence[str],
+    secrets: Sequence[Path],
+    directory: Path,
+) -> None:
+    """Initialize a new AxiomFlow project."""
+    directory.mkdir(parents=True, exist_ok=True)
+
+    dirs = [
+        "agents",
+        "adapters",
+        "workflows",
+        "evaluators",
+        "secrets",
+    ]
+    for d in dirs:
+        (directory / d).mkdir(exist_ok=True)
+
+    for secret_path in secrets:
+        target = directory / "secrets" / secret_path.name
+        shutil.copyfile(secret_path, target)
+        click.echo(f"Mounted secret {secret_path.name}")
+
+    project_config = {
+        "name": name,
+        "owner": owner,
+        "policies": list(policies),
+        "rbac": {
+            "roles": {"admin": {"permissions": ["*"]}},
+            "users": {owner: ["admin"]},
+        },
+    }
+    config_path = directory / "project.yaml"
+    config_path.write_text(yaml.safe_dump(project_config, sort_keys=False))
+
+    _run_smoke_test(directory, owner)
+    click.echo("Project initialized")
+
+
+def _run_smoke_test(base_dir: Path, owner: str) -> None:
+    try:
+        config_path = base_dir / "project.yaml"
+        data = yaml.safe_load(config_path.read_text())
+        required = [
+            "agents",
+            "adapters",
+            "workflows",
+            "evaluators",
+            "secrets",
+        ]
+        missing = [d for d in required if not (base_dir / d).is_dir()]
+        if missing:
+            raise click.ClickException(f"missing directories: {', '.join(missing)}")
+        if data.get("owner") != owner:
+            raise click.ClickException("owner mismatch")
+    except Exception as exc:  # pragma: no cover - unexpected failures
+        raise click.ClickException(f"Smoke test failed: {exc}") from exc

--- a/tests/cli/test_init_project.py
+++ b/tests/cli/test_init_project.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from axiomflow.cli.init_project import init_project
+
+
+def test_init_project_creates_structure(tmp_path: Path) -> None:
+    secret = tmp_path / "token.txt"
+    secret.write_text("s3cr3t")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        init_project,
+        [
+            "--name",
+            "demo",
+            "--owner",
+            "alice",
+            "--policy",
+            "policy1",
+            "--secret",
+            str(secret),
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    for d in ["agents", "adapters", "workflows", "evaluators", "secrets"]:
+        assert (tmp_path / d).is_dir()
+    data = yaml.safe_load((tmp_path / "project.yaml").read_text())
+    assert data["owner"] == "alice"
+    assert data["rbac"]["users"]["alice"] == ["admin"]
+    assert (tmp_path / "secrets" / "token.txt").read_text() == "s3cr3t"


### PR DESCRIPTION
## Summary
- add `init-project` CLI to scaffold AxiomFlow projects with RBAC and secrets mounting
- create project scaffolding test ensuring directories, config, and secrets are generated

## Testing
- `uv run ruff check src/axiomflow/cli/init_project.py tests/cli/test_init_project.py`
- `uv run pytest tests/cli/test_init_project.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba3b0ce46c83229e3c306ef5dcaffa