### PR TITLE
feat: configure adapter with signature and policy checks

### DIFF
--- a/configs/adapters.yaml
+++ b/configs/adapters.yaml
@@ -1,0 +1,2 @@
+proj-success:
+- acme/sample@1.0.0

--- a/configs/policies/allowed_scopes.yaml
+++ b/configs/policies/allowed_scopes.yaml
@@ -1,0 +1,3 @@
+allowed_scopes:
+  - read
+  - write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "psycopg[binary]>=3.2.9",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",
+    "pyyaml>=6.0.2",
     "redis>=6.4.0",
 ]
 

--- a/src/axiomflow/adapters/__init__.py
+++ b/src/axiomflow/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapter utilities."""
+
+from .configure import configure_adapter
+
+__all__ = ["configure_adapter"]

--- a/src/axiomflow/adapters/configure.py
+++ b/src/axiomflow/adapters/configure.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+from importlib import util
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+POLICY_FILE = REPO_ROOT / "configs" / "policies" / "allowed_scopes.yaml"
+REGISTRY_FILE = REPO_ROOT / "configs" / "adapters.yaml"
+INSTALL_BASE = REPO_ROOT / "adapters"
+
+
+def _verify_manifest(manifest: dict) -> dict:
+    payload = manifest.get("payload")
+    signature_b64 = manifest.get("signature")
+    public_key_b64 = manifest.get("public_key")
+    if payload is None or signature_b64 is None or public_key_b64 is None:
+        raise ValueError("Manifest missing required fields")
+    signature = base64.b64decode(signature_b64)
+    public_key = base64.b64decode(public_key_b64)
+    message = json.dumps(payload, sort_keys=True).encode()
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key).verify(signature, message)
+    except InvalidSignature as exc:  # pragma: no cover - edge case
+        raise ValueError("Invalid manifest signature") from exc
+    return payload
+
+
+def _validate_scopes(permissions: Sequence[str]) -> None:
+    allowed_data = yaml.safe_load(POLICY_FILE.read_text()) or {}
+    allowed_scopes = set(allowed_data.get("allowed_scopes", []))
+    if not set(permissions).issubset(allowed_scopes):
+        raise ValueError("Requested permissions exceed policy")
+
+
+def _register_adapter(project_id: str, adapter_id: str) -> None:
+    registry = {}
+    if REGISTRY_FILE.exists():
+        registry = yaml.safe_load(REGISTRY_FILE.read_text()) or {}
+    adapters = registry.get(project_id, [])
+    if adapter_id not in adapters:
+        adapters.append(adapter_id)
+    registry[project_id] = adapters
+    REGISTRY_FILE.write_text(yaml.safe_dump(registry))
+
+
+def _run_health_check(adapter_path: Path) -> bool:
+    init_file = adapter_path / "__init__.py"
+    if not init_file.exists():
+        return False
+    spec = util.spec_from_file_location(f"adapter_{adapter_path.name}", init_file)
+    if spec is None or spec.loader is None:
+        return False
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    health = getattr(module, "health_check", None)
+    if not callable(health):
+        return False
+    return bool(health())
+
+
+def configure_adapter(
+    adapter_id: str,
+    manifest_path: Path,
+    permissions: Sequence[str],
+    project_id: str,
+) -> dict:
+    """Configure and install an adapter.
+
+    Args:
+        adapter_id: Identifier in the form org/name@version.
+        manifest_path: Path to the signed manifest file.
+        permissions: Requested permission scopes.
+        project_id: Target project identifier.
+
+    Returns:
+        Mapping containing installation status and health check result.
+
+    Raises:
+        ValueError: If manifest verification, scope validation, or health check fails.
+    """
+
+    manifest = json.loads(Path(manifest_path).read_text())
+    payload = _verify_manifest(manifest)
+    _validate_scopes(permissions)
+
+    safe_name = adapter_id.replace("/", "_")
+    dest = INSTALL_BASE / project_id / safe_name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(payload["source"], dest, dirs_exist_ok=True)
+
+    _register_adapter(project_id, adapter_id)
+
+    if not _run_health_check(dest):
+        raise ValueError("Adapter health check failed")
+
+    return {"installation_status": "success", "health_check_result": True}

--- a/tests/adapters/test_configure.py
+++ b/tests/adapters/test_configure.py
@@ -1,0 +1,75 @@
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from axiomflow.adapters import configure_adapter
+
+
+def _create_adapter(tmp_path: Path) -> Path:
+    adapter_dir = tmp_path / "sample_adapter"
+    adapter_dir.mkdir()
+    adapter_dir.joinpath("__init__.py").write_text(
+        "def health_check():\n    return True\n"
+    )
+    return adapter_dir
+
+
+def _create_manifest(tmp_path: Path, adapter_dir: Path) -> Path:
+    key = Ed25519PrivateKey.generate()
+    public_key = key.public_key()
+    payload = {"source": str(adapter_dir)}
+    message = json.dumps(payload, sort_keys=True).encode()
+    signature = key.sign(message)
+    manifest = {
+        "payload": payload,
+        "public_key": base64.b64encode(
+            public_key.public_bytes(Encoding.Raw, PublicFormat.Raw)
+        ).decode(),
+        "signature": base64.b64encode(signature).decode(),
+    }
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+    return path, manifest
+
+
+def test_configure_adapter_success(tmp_path: Path) -> None:
+    adapter_dir = _create_adapter(tmp_path)
+    manifest_path, manifest = _create_manifest(tmp_path, adapter_dir)
+
+    result = configure_adapter(
+        "acme/sample@1.0.0", manifest_path, ["read"], "proj-success"
+    )
+    assert result == {"installation_status": "success", "health_check_result": True}
+    installed = Path("adapters/proj-success/acme_sample@1.0.0")
+    assert installed.exists()
+    registry = yaml.safe_load(Path("configs/adapters.yaml").read_text())
+    assert "acme/sample@1.0.0" in registry["proj-success"]
+
+
+def test_configure_adapter_invalid_scope(tmp_path: Path) -> None:
+    adapter_dir = _create_adapter(tmp_path)
+    manifest_path, _ = _create_manifest(tmp_path, adapter_dir)
+
+    with pytest.raises(ValueError):
+        configure_adapter(
+            "acme/sample@1.0.0", manifest_path, ["admin"], "proj-bad-scope"
+        )
+
+
+def test_configure_adapter_bad_signature(tmp_path: Path) -> None:
+    adapter_dir = _create_adapter(tmp_path)
+    manifest_path, manifest = _create_manifest(tmp_path, adapter_dir)
+    bad = json.loads(manifest_path.read_text())
+    bad["signature"] = base64.b64encode(b"0" * 64).decode()
+    manifest_path.write_text(json.dumps(bad))
+
+    with pytest.raises(ValueError):
+        configure_adapter("acme/sample@1.0.0", manifest_path, ["read"], "proj-bad-sig")

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "redis" },
 ]
 
@@ -69,6 +70,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "redis", specifier = ">=6.4.0" },
 ]
 


### PR DESCRIPTION
## Summary
- add `configure_adapter` to install adapters securely and run health checks
- track allowed scopes via `configs/policies/allowed_scopes.yaml`
- cover adapter configuration with tests for scope and signature validation

## Testing
- `uv run black .`
- `uv run isort src/axiomflow/adapters tests/adapters`
- `uv run ruff check .`
- `uv run bandit -r src/`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68ba3bdcc4448322ae4f6eea7712ff8f