### PR TITLE
feat: add recovery manager and workflow executor integration

### DIFF
--- a/src/axiomflow/runtime/executor.py
+++ b/src/axiomflow/runtime/executor.py
@@ -1,0 +1,33 @@
+"""Simple workflow execution engine with recovery integration."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .recovery import RecoveryManager, RetryPolicy
+
+
+class WorkflowExecutor:
+    """Execute workflow steps with automatic recovery."""
+
+    def __init__(self, recovery_manager: RecoveryManager | None = None) -> None:
+        self.recovery_manager = recovery_manager or RecoveryManager()
+
+    async def run_step(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        retry_policy: RetryPolicy | None = None,
+        compensation: Callable[[Exception], Any] | None = None,
+        cleanup: Callable[[], Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run a workflow step using the recovery manager."""
+        return await self.recovery_manager.execute(
+            func,
+            *args,
+            retry_policy=retry_policy,
+            compensation=compensation,
+            cleanup=cleanup,
+            **kwargs,
+        )

--- a/src/axiomflow/runtime/recovery.py
+++ b/src/axiomflow/runtime/recovery.py
@@ -1,0 +1,80 @@
+"""Recovery utilities for agent and tool execution."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, List
+
+
+@dataclass
+class RetryPolicy:
+    """Configuration for retry behaviour."""
+
+    max_attempts: int = 3
+    strategy: str = "exponential"
+    base_delay: float = 0.1
+    max_delay: float = 1.0
+
+    def backoff(self, attempt: int) -> float:
+        """Compute delay before the next attempt."""
+        if self.strategy == "linear":
+            delay = self.base_delay * attempt
+        else:
+            delay = self.base_delay * (2 ** (attempt - 1))
+        return min(delay, self.max_delay)
+
+
+async def _maybe_await(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Invoke ``func`` and await the result if needed."""
+    result = func(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+class RecoveryManager:
+    """Monitor errors and perform recovery actions."""
+
+    def __init__(
+        self,
+        *,
+        escalation_hook: (
+            Callable[[List[Exception]], Awaitable[None] | None] | None
+        ) = None,
+    ) -> None:
+        self.escalation_hook = escalation_hook
+        self.errors: List[Exception] = []
+
+    async def execute(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        retry_policy: RetryPolicy | None = None,
+        compensation: Callable[[Exception], Awaitable[None] | None] | None = None,
+        cleanup: Callable[[], Awaitable[None] | None] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Execute ``func`` with retry and recovery logic."""
+        policy = retry_policy or RetryPolicy()
+        attempt = 0
+        try:
+            while True:
+                try:
+                    return await _maybe_await(func, *args, **kwargs)
+                except Exception as exc:  # pragma: no cover - broad for recovery
+                    self.errors.append(exc)
+                    attempt += 1
+                    if compensation:
+                        await _maybe_await(compensation, exc)
+                    if attempt >= policy.max_attempts:
+                        raise
+                    await asyncio.sleep(policy.backoff(attempt))
+        except Exception:
+            if self.escalation_hook:
+                await _maybe_await(self.escalation_hook, self.errors)
+            raise
+        finally:
+            if cleanup:
+                await _maybe_await(cleanup)

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from axiomflow.runtime.executor import WorkflowExecutor
+from axiomflow.runtime.recovery import RetryPolicy
+
+
+def test_executor_uses_recovery_manager():
+    async def runner():
+        attempts = 0
+
+        async def flaky():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 2:
+                raise ValueError("fail")
+            return "done"
+
+        executor = WorkflowExecutor()
+        policy = RetryPolicy(max_attempts=3, base_delay=0)
+        result = await executor.run_step(flaky, retry_policy=policy)
+        assert result == "done"
+
+    asyncio.run(runner())

--- a/tests/runtime/test_recovery.py
+++ b/tests/runtime/test_recovery.py
@@ -1,0 +1,60 @@
+import asyncio
+
+import pytest
+
+from axiomflow.runtime.recovery import RecoveryManager, RetryPolicy
+
+
+def test_recovery_manager_retries_and_cleans_up():
+    async def runner():
+        attempts = 0
+        compensation_calls = []
+        cleaned = False
+
+        async def flaky():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise ValueError("boom")
+            return "ok"
+
+        async def compensation(exc: Exception) -> None:
+            compensation_calls.append(type(exc))
+
+        async def cleanup() -> None:
+            nonlocal cleaned
+            cleaned = True
+
+        manager = RecoveryManager()
+        policy = RetryPolicy(max_attempts=5, strategy="linear", base_delay=0)
+        result = await manager.execute(
+            flaky, compensation=compensation, cleanup=cleanup, retry_policy=policy
+        )
+
+        assert result == "ok"
+        assert len(compensation_calls) == 2
+        assert cleaned
+
+    asyncio.run(runner())
+
+
+def test_recovery_manager_escalates_after_failures():
+    async def runner():
+        escalated = False
+
+        async def always_fail():
+            raise RuntimeError("nope")
+
+        async def escalate(errors):
+            nonlocal escalated
+            escalated = True
+
+        manager = RecoveryManager(escalation_hook=escalate)
+        policy = RetryPolicy(max_attempts=2, base_delay=0)
+
+        with pytest.raises(RuntimeError):
+            await manager.execute(always_fail, retry_policy=policy)
+
+        assert escalated
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add recovery utilities with retry, compensation, and escalation hooks
- integrate workflow executor with recovery manager
- cover recovery scenarios with unit tests

## Testing
- `uv run ruff check .`
- `uv run bandit -r src/`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68ba3d0172248322b0f9403b47e3a333