### PR TITLE
feat: add security scan evaluator

### DIFF
--- a/evaluators/pf03_security.py
+++ b/evaluators/pf03_security.py
@@ -1,0 +1,104 @@
+"""PF-03 security evaluator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any, Iterable
+
+
+def _run_command(cmd: list[str]) -> str:
+    """Execute a command and return its stdout."""
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return proc.stdout
+
+
+def _has_high(findings: list[dict[str, Any]], key: str = "severity") -> bool:
+    """Return True if any finding has high or critical severity."""
+    for item in findings:
+        severity = str(item.get(key, "")).lower()
+        if severity in {"high", "critical"}:
+            return True
+    return False
+
+
+def pf03_security_scan(paths: Iterable[str | bytes]) -> dict[str, Any]:
+    """Run security tools and raise on high or critical findings.
+
+    Args:
+        paths: Iterable of paths to analyse.
+
+    Returns:
+        Aggregated security report from all tools.
+    """
+    path_list = [str(p) for p in paths]
+    report: dict[str, Any] = {}
+    failed = False
+
+    # Semgrep
+    semgrep_cmd = ["semgrep", "--config", "p/ci", "--json", *path_list]
+    semgrep_out = _run_command(semgrep_cmd)
+    semgrep_data = json.loads(semgrep_out or "{}")
+    report["semgrep"] = semgrep_data
+    semgrep_findings = [r.get("extra", {}) for r in semgrep_data.get("results", [])]
+    if _has_high(semgrep_findings):
+        failed = True
+
+    # Bandit
+    bandit_cmd = ["bandit", "-r", *path_list, "-f", "json"]
+    bandit_out = _run_command(bandit_cmd)
+    bandit_data = json.loads(bandit_out or "{}")
+    report["bandit"] = bandit_data
+    bandit_findings = [
+        {"severity": r.get("issue_severity", "")}
+        for r in bandit_data.get("results", [])
+    ]
+    if _has_high(bandit_findings):
+        failed = True
+
+    # ESLint
+    eslint_cmd = ["pnpm", "exec", "eslint", *path_list, "--format", "json"]
+    eslint_out = _run_command(eslint_cmd)
+    try:
+        eslint_data = json.loads(eslint_out or "[]")
+    except json.JSONDecodeError:
+        eslint_data = []
+    report["eslint"] = eslint_data
+    eslint_findings = []
+    for file_result in eslint_data:
+        for msg in file_result.get("messages", []):
+            severity = "high" if msg.get("severity") == 2 else "medium"
+            eslint_findings.append({"severity": severity})
+    if _has_high(eslint_findings):
+        failed = True
+
+    # pip-audit
+    pip_cmd = ["pip-audit", "-f", "json"]
+    pip_out = _run_command(pip_cmd)
+    pip_data = json.loads(pip_out or "{}")
+    report["pip_audit"] = pip_data
+    dependencies = (
+        pip_data.get("dependencies", []) if isinstance(pip_data, dict) else []
+    )
+    pip_findings = []
+    for dep in dependencies:
+        for vuln in dep.get("vulns", []):
+            pip_findings.append({"severity": vuln.get("severity", "")})
+    if _has_high(pip_findings):
+        failed = True
+
+    # npm audit
+    npm_cmd = ["pnpm", "audit", "--json"]
+    npm_out = _run_command(npm_cmd)
+    npm_data = json.loads(npm_out or "{}")
+    report["npm_audit"] = npm_data
+    npm_findings = []
+    for info in npm_data.get("vulnerabilities", {}).values():
+        npm_findings.append({"severity": info.get("severity", "")})
+    if _has_high(npm_findings):
+        failed = True
+
+    if failed:
+        raise RuntimeError("High severity security issues detected")
+
+    return report

--- a/tests/test_pf03_security.py
+++ b/tests/test_pf03_security.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location(
+    "pf03_security", ROOT / "evaluators" / "pf03_security.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+pf03_security_scan = module.pf03_security_scan
+
+
+def test_pf03_security_scan_raises(monkeypatch):
+    def fake_run(cmd: list[str]) -> str:  # noqa: ARG001
+        if cmd and cmd[0] == "semgrep":
+            return json.dumps({"results": [{"extra": {"severity": "HIGH"}}]})
+        if cmd and cmd[0] == "bandit":
+            return json.dumps({"results": []})
+        if cmd and cmd[0] == "pnpm" and cmd[1] == "exec":
+            return json.dumps([])
+        if cmd and cmd[0] == "pip-audit":
+            return json.dumps({"dependencies": []})
+        if cmd and cmd[0] == "pnpm" and cmd[1] == "audit":
+            return json.dumps({"vulnerabilities": {}})
+        return ""
+
+    monkeypatch.setattr(module, "_run_command", fake_run)
+
+    with pytest.raises(RuntimeError):
+        pf03_security_scan(["src"])
+
+
+def test_pf03_security_scan_passes(monkeypatch):
+    def fake_run(cmd: list[str]) -> str:  # noqa: ARG001
+        if cmd and cmd[0] == "semgrep":
+            return json.dumps({"results": [{"extra": {"severity": "LOW"}}]})
+        if cmd and cmd[0] == "bandit":
+            return json.dumps({"results": []})
+        if cmd and cmd[0] == "pnpm" and cmd[1] == "exec":
+            return json.dumps([])
+        if cmd and cmd[0] == "pip-audit":
+            return json.dumps({"dependencies": []})
+        if cmd and cmd[0] == "pnpm" and cmd[1] == "audit":
+            return json.dumps({"vulnerabilities": {}})
+        return ""
+
+    monkeypatch.setattr(module, "_run_command", fake_run)
+
+    result = pf03_security_scan(["src"])
+    assert "semgrep" in result
+    assert result["semgrep"]["results"][0]["extra"]["severity"] == "LOW"


### PR DESCRIPTION
## Summary
- add PF-03 security scan evaluator running Semgrep, Bandit, ESLint, pip-audit and npm audit
- ensure evaluator fails on high/critical findings
- test evaluator behaviour for both failing and passing scenarios

## Testing
- `uv run black evaluators/pf03_security.py tests/test_pf03_security.py`
- `uv run isort evaluators/pf03_security.py tests/test_pf03_security.py`
- `uv run ruff check evaluators/pf03_security.py tests/test_pf03_security.py`
- `uv run pytest tests`
- `uv run bandit -r src evaluators`
- `semgrep --config=p/ci --json src evaluators` *(fail: command not found)*
- `pip-audit -f json` *(fail: command not found)*
- `pnpm exec eslint .` *(fail: No package found in this workspace)*
- `pnpm audit --json` *(fail: No pnpm-lock.yaml found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba42f5c43483228f234614d4f93d76