### PR TITLE
feat: enable router learning from outcomes

### DIFF
--- a/tests/runtime/test_routing.py
+++ b/tests/runtime/test_routing.py
@@ -1,13 +1,11 @@
-from typing import List
+import json
+from typing import Dict, List
 from unittest.mock import AsyncMock
 
 import pytest
 
-from axiomflow.runtime.router import (
-    AgentRouter,
-    NoAgentsAvailableError,
-    PolicyViolationError,
-)
+from axiomflow.runtime.router import (AgentRouter, NoAgentsAvailableError,
+                                      PolicyViolationError)
 
 pytestmark = pytest.mark.anyio
 
@@ -117,3 +115,51 @@ async def test_routing_accuracy(agents):
         elif t["required_skill"] == "ml" and result["id"] == "agent_ml":
             correct += 1
     assert correct / len(tasks) >= 0.95
+
+
+async def test_model_adapts_after_feedback(tmp_path):
+    class SimpleModel:
+        def __init__(self) -> None:
+            self.stats: Dict[str, Dict[str, int]] = {}
+
+        async def score(self, features):
+            stat = self.stats.get(features["agent_id"], {"success": 0, "total": 0})
+            return (stat["success"] + 1) / (stat["total"] + 2)
+
+        async def update(self, features):
+            stat = self.stats.setdefault(
+                features["agent_id"], {"success": 0, "total": 0}
+            )
+            stat["total"] += 1
+            if features["result"]:
+                stat["success"] += 1
+
+    agents = [
+        {
+            "id": "agent_a",
+            "skills": {"python"},
+            "load": 0.2,
+            "policies": set(),
+            "status": "available",
+        },
+        {
+            "id": "agent_b",
+            "skills": {"python"},
+            "load": 0.2,
+            "policies": set(),
+            "status": "available",
+        },
+    ]
+    metrics_file = tmp_path / "metrics.json"
+    router = AgentRouter(SimpleModel(), metrics_path=metrics_file)
+    task = {"required_skill": "python"}
+    first = await router.route_task(task, agents)
+    await router.record_outcome(task, first, False)
+    second = await router.route_task(task, agents)
+    await router.record_outcome(task, second, True)
+    third = await router.route_task(task, agents)
+    assert second["id"] != first["id"]
+    assert third["id"] == second["id"]
+    data = json.loads(metrics_file.read_text())
+    assert data[first["id"]]["failure"] == 1
+    assert data[second["id"]]["success"] == 1


### PR DESCRIPTION
## Summary
- track agent outcomes and update routing metrics persistently
- expose `record_outcome` to feed results back into the model
- test that router adapts routing decisions after feedback

## Testing
- `uv run black .`
- `uv run isort src/axiomflow/runtime/router.py tests/runtime/test_routing.py`
- `uv run ruff check .`
- `uv run bandit -r src/`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68ba4c7ce10c83229b90c1b8c13ce76e