### PR TITLE
feat: add workflow estimation and dry-run support

### DIFF
--- a/src/axiomflow/dsl/parser.py
+++ b/src/axiomflow/dsl/parser.py
@@ -39,6 +39,7 @@ class WorkflowParser:
         workflow = data["workflow"]
         self._validate_schema(workflow)
         self._validate_semantics(workflow)
+        workflow["estimates"] = self._estimate_resources(workflow)
         logger.debug("Workflow parsed successfully")
         return workflow
 
@@ -135,3 +136,19 @@ class WorkflowParser:
 
         for start in list(graph):
             visit(start)
+
+    def _estimate_resources(self, workflow: Dict[str, Any]) -> Dict[str, float]:
+        """Compute aggregate runtime and cost estimates for a workflow.
+
+        Args:
+            workflow: Workflow dictionary.
+
+        Returns:
+            Dictionary containing total ``runtime`` and ``cost`` estimates.
+        """
+        runtime = 0.0
+        cost = 0.0
+        for step in workflow.get("steps", []):
+            runtime += float(step.get("estimated_runtime", 0.0))
+            cost += float(step.get("estimated_cost", 0.0))
+        return {"runtime": runtime, "cost": cost}

--- a/src/axiomflow/runtime/executor.py
+++ b/src/axiomflow/runtime/executor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, Dict, List
 
 from .recovery import RecoveryManager, RetryPolicy
 
@@ -31,3 +31,63 @@ class WorkflowExecutor:
             cleanup=cleanup,
             **kwargs,
         )
+
+    async def run_workflow(
+        self,
+        workflow: Dict[str, Any],
+        step_funcs: Dict[str, Callable[..., Any]],
+        dry_run: bool = False,
+    ) -> Dict[str, float]:
+        """Execute all workflow steps respecting dependencies.
+
+        Args:
+            workflow: Parsed workflow dictionary.
+            step_funcs: Mapping of step IDs to callables.
+            dry_run: If ``True``, walk the graph without executing steps.
+
+        Returns:
+            Dictionary with actual ``runtime`` and ``cost`` totals.
+        """
+        order = self._topological_sort(workflow)
+        total_runtime = 0.0
+        total_cost = 0.0
+        for step in order:
+            sid = step["id"]
+            func = step_funcs.get(sid)
+            if dry_run:
+                continue
+            if func is None:
+                raise ValueError(f"Missing function for step {sid}")
+            result = await self.run_step(func)
+            if isinstance(result, dict):
+                total_runtime += float(result.get("runtime", 0.0))
+                total_cost += float(result.get("cost", 0.0))
+        return {"runtime": total_runtime, "cost": total_cost}
+
+    def _topological_sort(self, workflow: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Return workflow steps in dependency order.
+
+        Args:
+            workflow: Workflow dictionary.
+
+        Returns:
+            List of step dictionaries sorted topologically.
+        """
+        steps = {s["id"]: s for s in workflow.get("steps", [])}
+        in_degree = {sid: 0 for sid in steps}
+        for edge in workflow.get("edges", []):
+            in_degree[edge["to"]] += 1
+        queue = [sid for sid, deg in in_degree.items() if deg == 0]
+        order: List[Dict[str, Any]] = []
+        while queue:
+            sid = queue.pop(0)
+            order.append(steps[sid])
+            for edge in workflow.get("edges", []):
+                if edge["from"] == sid:
+                    to = edge["to"]
+                    in_degree[to] -= 1
+                    if in_degree[to] == 0:
+                        queue.append(to)
+        if len(order) != len(steps):
+            raise ValueError("Circular dependency detected")
+        return order

--- a/tests/dsl/test_parser.py
+++ b/tests/dsl/test_parser.py
@@ -74,6 +74,42 @@ VALID_WORKFLOW_JSON = """
 }
 """
 
+ESTIMATE_WORKFLOW_YAML = """
+workflow:
+  name: estimate-workflow
+  version: "1.0.0"
+  inputs: []
+  personas:
+    - id: dev
+      name: Developer
+      role: coder
+      capabilities: [code]
+  steps:
+    - id: step1
+      name: Step One
+      persona: dev
+      action: run
+      inputs: {}
+      outputs:
+        result: string
+      estimated_runtime: 1.0
+      estimated_cost: 10.0
+    - id: step2
+      name: Step Two
+      persona: dev
+      action: run
+      inputs:
+        prev_result: step1.result
+      outputs:
+        final: string
+      estimated_runtime: 2.0
+      estimated_cost: 20.0
+  edges:
+    - from: step1
+      to: step2
+  gates: []
+"""
+
 
 def test_parse_yaml_workflow():
     parser = WorkflowParser()
@@ -132,3 +168,10 @@ def test_invalid_retry_config():
     parser = WorkflowParser()
     with pytest.raises(ValueError):
         parser.parse(yaml_text)
+
+
+def test_parse_estimates():
+    parser = WorkflowParser()
+    result = parser.parse(ESTIMATE_WORKFLOW_YAML)
+    assert result["estimates"]["runtime"] == 3.0
+    assert result["estimates"]["cost"] == 30.0

--- a/tests/runtime/test_workflow_run.py
+++ b/tests/runtime/test_workflow_run.py
@@ -1,0 +1,75 @@
+import asyncio
+
+from axiomflow.dsl.parser import WorkflowParser
+from axiomflow.runtime.executor import WorkflowExecutor
+
+WORKFLOW_YAML = """
+workflow:
+  name: estimate-workflow
+  version: "1.0.0"
+  inputs: []
+  personas:
+    - id: dev
+      name: Developer
+      role: coder
+      capabilities: [code]
+  steps:
+    - id: step1
+      name: Step One
+      persona: dev
+      action: run
+      inputs: {}
+      outputs:
+        result: string
+      estimated_runtime: 1.0
+      estimated_cost: 10.0
+    - id: step2
+      name: Step Two
+      persona: dev
+      action: run
+      inputs:
+        prev_result: step1.result
+      outputs:
+        final: string
+      estimated_runtime: 2.0
+      estimated_cost: 20.0
+  edges:
+    - from: step1
+      to: step2
+  gates: []
+"""
+
+
+async def _step1():
+    return {"runtime": 1.1, "cost": 11.0}
+
+
+async def _step2():
+    return {"runtime": 2.4, "cost": 18.0}
+
+
+def test_estimation_accuracy_within_20_percent():
+    parser = WorkflowParser()
+    workflow = parser.parse(WORKFLOW_YAML)
+    executor = WorkflowExecutor()
+    step_funcs = {"step1": _step1, "step2": _step2}
+    actual = asyncio.run(executor.run_workflow(workflow, step_funcs))
+    estimate = workflow["estimates"]
+    for key in ("runtime", "cost"):
+        diff = abs(actual[key] - estimate[key]) / estimate[key]
+        assert diff <= 0.2
+
+
+def test_dry_run_produces_no_calls():
+    parser = WorkflowParser()
+    workflow = parser.parse(WORKFLOW_YAML)
+    calls: list[str] = []
+
+    async def recorder():
+        calls.append("called")
+        return {"runtime": 0.0, "cost": 0.0}
+
+    executor = WorkflowExecutor()
+    step_funcs = {"step1": recorder, "step2": recorder}
+    asyncio.run(executor.run_workflow(workflow, step_funcs, dry_run=True))
+    assert not calls


### PR DESCRIPTION
## Summary
- compute aggregate runtime and cost estimates when parsing workflows
- support dry-run execution option to traverse workflow graphs without side effects
- test estimation accuracy and dry-run behavior

## Testing
- `uv run black src/axiomflow/dsl/parser.py src/axiomflow/runtime/executor.py tests/dsl/test_parser.py tests/runtime/test_workflow_run.py`
- `uv run isort src/axiomflow/dsl/parser.py src/axiomflow/runtime/executor.py tests/dsl/test_parser.py tests/runtime/test_workflow_run.py --check-only`
- `uv run ruff check .`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68ba4efc10988322a36bdd790d5088a3