### PR TITLE
feat: add project initialization CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "redis>=6.4.0",
 ]
 
+[project.scripts]
+axiomflow = "axiomflow.cli.init:cli"
+
 [dependency-groups]
 dev = [
     "bandit>=1.8.6",

--- a/src/axiomflow/cli/init.py
+++ b/src/axiomflow/cli/init.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+import click
+import yaml
+
+SKELETON_DIRS = ["agents", "workflows", "configs", "configs/secrets"]
+
+
+def initialize_project(project_name: str) -> Path:
+    """Create a new AxiomFlow project skeleton.
+
+    Args:
+        project_name: Name of the project to create.
+
+    Returns:
+        Path to the created project directory.
+    """
+    base_dir = Path(project_name).resolve()
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    for directory in SKELETON_DIRS:
+        (base_dir / directory).mkdir(parents=True, exist_ok=True)
+
+    roles_path = base_dir / "configs" / "roles.yaml"
+    if not roles_path.exists():
+        roles_path.write_text("roles:\n  admin:\n    permissions:\n      - '*'\n")
+
+    secrets_dir = base_dir / "configs" / "secrets"
+    (secrets_dir / ".gitkeep").touch(exist_ok=True)
+
+    project_yaml = {
+        "name": project_name,
+        "created": _dt.datetime.utcnow().isoformat(),
+        "metadata": {},
+    }
+    (base_dir / "project.yaml").write_text(
+        yaml.safe_dump(project_yaml, sort_keys=False)
+    )
+
+    _run_smoke_test(base_dir)
+    return base_dir
+
+
+def _run_smoke_test(base_dir: Path) -> None:
+    required = ["agents", "workflows", "configs", "configs/secrets"]
+    missing = [d for d in required if not (base_dir / d).is_dir()]
+    if missing:
+        raise click.ClickException(f"missing directories: {', '.join(missing)}")
+    if not (base_dir / "project.yaml").is_file():
+        raise click.ClickException("project.yaml not found")
+    if not (base_dir / "configs" / "roles.yaml").is_file():
+        raise click.ClickException("roles.yaml missing")
+
+
+@click.group()
+def cli() -> None:
+    """AxiomFlow command line interface."""
+
+
+@cli.command()
+@click.argument("project_name")
+def init(project_name: str) -> None:
+    """Initialize a new AxiomFlow project."""
+    initialize_project(project_name)
+    click.echo(f"Initialized project {project_name}")

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+import click
+import pytest
+import yaml
+from click.testing import CliRunner
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from axiomflow.cli.init import _run_smoke_test, cli, initialize_project
+
+
+def test_initialize_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    initialize_project("demo")
+    base = tmp_path / "demo"
+    for d in ["agents", "workflows", "configs", "configs/secrets"]:
+        assert (base / d).exists()
+    assert (base / "configs" / "roles.yaml").is_file()
+    assert (base / "configs" / "secrets" / ".gitkeep").is_file()
+    data = yaml.safe_load((base / "project.yaml").read_text())
+    assert data["name"] == "demo"
+    assert "created" in data
+
+
+def test_cli_init(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(cli, ["init", "demo"])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "demo" / "agents").is_dir()
+
+
+def test_smoke_test_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    base = initialize_project("demo")
+    (base / "agents").rmdir()
+    with pytest.raises(click.ClickException):
+        _run_smoke_test(base)


### PR DESCRIPTION
## Summary
- add `axiomflow init` command to scaffold project skeleton and config files
- generate default RBAC roles and secrets placeholders
- include smoke test and unit tests for project initialization

## Testing
- `uv run black src/axiomflow/cli/init.py tests/cli/test_init.py`
- `uv run isort src/axiomflow/cli/init.py tests/cli/test_init.py`
- `uv run ruff check src/axiomflow/cli/init.py tests/cli/test_init.py`
- `uv run bandit -r src/axiomflow/cli/init.py`
- `uv run pytest tests/ --cov=src/`


------
https://chatgpt.com/codex/tasks/task_e_68ba562d32988322a6c440fec1a6bf0e