### PR TITLE
feat: implement PF-05 replay validation

### DIFF
--- a/evaluators/__init__.py
+++ b/evaluators/__init__.py
@@ -1,1 +1,18 @@
+"""Evaluator exports."""
 
+from .pf01_api_validation import pf01_validate_apis
+from .pf02_deprecation import pf02_check_deprecations
+from .pf03_security import pf03_security_scan
+from .pf04_dependencies import pf04_validate_dependencies
+from .pf05_replay_validation import generate_reports, pf05_validate_replay
+from .runner import run_pf05
+
+__all__ = [
+    "pf01_validate_apis",
+    "pf02_check_deprecations",
+    "pf03_security_scan",
+    "pf04_validate_dependencies",
+    "pf05_validate_replay",
+    "generate_reports",
+    "run_pf05",
+]

--- a/evaluators/pf05_replay_validation.py
+++ b/evaluators/pf05_replay_validation.py
@@ -1,0 +1,69 @@
+"""PF-05 replay validation evaluator."""
+
+from __future__ import annotations
+
+import json
+import random
+from typing import Any, Callable, Sequence
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - numpy is optional
+    np = None
+
+
+def _capture_state() -> dict[str, Any]:
+    """Capture RNG states for reproducible replays."""
+    state: dict[str, Any] = {"random": random.getstate()}
+    if np is not None:
+        state["numpy"] = np.random.get_state()
+    return state
+
+
+def _restore_state(state: dict[str, Any]) -> None:
+    """Restore RNG states from *state*."""
+    random.setstate(state["random"])
+    if np is not None and "numpy" in state:
+        np.random.set_state(state["numpy"])
+
+
+def _compare(a: Any, b: Any) -> float:
+    """Return match ratio between *a* and *b*."""
+    if (
+        isinstance(a, Sequence)
+        and isinstance(b, Sequence)
+        and not isinstance(a, (str, bytes))
+        and not isinstance(b, (str, bytes))
+    ):
+        total = max(len(a), len(b))
+        if total == 0:
+            return 1.0
+        matches = sum(1 for x, y in zip(a, b) if x == y)
+        return matches / total
+    return 1.0 if a == b else 0.0
+
+
+def pf05_validate_replay(
+    func: Callable[..., Any], *args: Any, **kwargs: Any
+) -> dict[str, Any]:
+    """Execute *func* twice under captured RNG state and compare outputs."""
+    state = _capture_state()
+    output = func(*args, **kwargs)
+    record = {"args": args, "kwargs": kwargs, "state": state, "output": output}
+    _restore_state(state)
+    replay_output = func(*args, **kwargs)
+    match_ratio = _compare(output, replay_output)
+    return {
+        "record": record,
+        "replay_output": replay_output,
+        "match_ratio": match_ratio,
+    }
+
+
+def generate_reports(result: dict[str, Any]) -> tuple[str, str]:
+    """Generate JSON and Markdown reports for *result*."""
+    json_report = json.dumps(result, default=str, indent=2)
+    md_report = (
+        "# PF-05 Replay Validation\n\n" f"- Match ratio: {result['match_ratio']:.2%}\n"
+    )
+    return json_report, md_report

--- a/evaluators/runner.py
+++ b/evaluators/runner.py
@@ -1,0 +1,20 @@
+"""Evaluator runner utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .pf05_replay_validation import generate_reports, pf05_validate_replay
+
+
+def run_pf05(
+    func: Callable[..., Any], *args: Any, **kwargs: Any
+) -> dict[str, str | float]:
+    """Run PF-05 replay validation and return reports."""
+    result = pf05_validate_replay(func, *args, **kwargs)
+    json_report, md_report = generate_reports(result)
+    return {
+        "match_ratio": result["match_ratio"],
+        "json": json_report,
+        "markdown": md_report,
+    }

--- a/tests/test_pf05_replay_validation.py
+++ b/tests/test_pf05_replay_validation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import random
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location(
+    "pf05_replay_validation", ROOT / "evaluators" / "pf05_replay_validation.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+pf05_validate_replay = module.pf05_validate_replay
+generate_reports = module.generate_reports
+
+
+spec_runner = importlib.util.spec_from_file_location(
+    "evaluators.runner", ROOT / "evaluators" / "runner.py"
+)
+runner_module = importlib.util.module_from_spec(spec_runner)
+spec_runner.loader.exec_module(runner_module)
+
+run_pf05 = runner_module.run_pf05
+
+
+def random_sequence(length: int) -> list[int]:
+    return [random.randint(0, 100) for _ in range(length)]
+
+
+def test_pf05_replay_validation():
+    result = pf05_validate_replay(random_sequence, 50)
+    assert result["match_ratio"] >= 0.85
+    json_report, md_report = generate_reports(result)
+    assert '"match_ratio"' in json_report
+    assert "PF-05 Replay Validation" in md_report
+
+
+def test_run_pf05():
+    outcome = run_pf05(random_sequence, 20)
+    assert outcome["match_ratio"] >= 0.85
+    assert "Match ratio" in outcome["markdown"]


### PR DESCRIPTION
## Summary
- add replay validation evaluator capturing RNG state and generating JSON/Markdown reports
- integrate PF-05 with evaluator runner
- cover replay matching with unit tests

## Testing
- `uv run ruff check evaluators/runner.py evaluators/pf05_replay_validation.py tests/test_pf05_replay_validation.py evaluators/__init__.py`
- `uv run bandit -q -r evaluators/pf05_replay_validation.py`
- `uv run pytest tests/test_pf05_replay_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba6ab88fec832291f43d98c22b7505